### PR TITLE
Fix deprecation in DoctrineMigrationsSafeMigration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ If you prefer to develop without Docker:
    }
    ```
 
-2. **Register the rule** in `phpstan.neon`:
+2. **Register the rule** in `extension.neon`:
    ```yaml
    rules:
        - NijiDigital\PhpStanRules\Rules\YourNewRule

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ If you also install [phpstan/extension-installer](https://github.com/phpstan/ext
 <details>
   <summary>Manual installation</summary>
 
-If you don't want to use `phpstan/extension-installer`, include phpstan.neon in your project's PHPStan config:
+If you don't want to use `phpstan/extension-installer`, include extension.neon in your project's PHPStan config:
 
 ```
 includes:
-    - vendor/nijidigital/phpstan-rules/phpstan.neon
+    - vendor/nijidigital/phpstan-rules/extension.neon
 ```
 </details>
 

--- a/composer.json
+++ b/composer.json
@@ -26,12 +26,13 @@
         "phpunit/phpunit": "^11.5",
         "rector/rector": "^1.0",
         "friendsofphp/php-cs-fixer": "^3.86",
-        "doctrine/migrations": "^3.9"
+        "doctrine/migrations": "^3.9",
+        "phpstan/phpstan-deprecation-rules": "^1"
     },
     "extra": {
         "phpstan": {
             "includes": [
-                "phpstan.neon"
+                "extension.neon"
             ]
         }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5b71590469f1654bd83b8e812ee1eb8f",
+    "content-hash": "ec3dd0576e64f05d90dee5c3173e5d1a",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -1196,6 +1196,53 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-deprecation-rules",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
+                "reference": "f94d246cc143ec5a23da868f8f7e1393b50eaa82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/f94d246cc143ec5a23da868f8f7e1393b50eaa82",
+                "reference": "f94d246cc143ec5a23da868f8f7e1393b50eaa82",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.12"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.2.1"
+            },
+            "time": "2024-09-11T15:52:35+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/extension.neon
+++ b/extension.neon
@@ -1,0 +1,41 @@
+parameters:
+    niji:
+        doctrineMigrations:
+            safeMigration:
+                blacklistedQueries: null
+                safeMigrationTag: null
+            description:
+                acceptedPattern: null
+
+parametersSchema:
+	niji: structure([
+        doctrineMigrations: structure([
+            safeMigration: structure([
+                blacklistedQueries: schema(arrayOf(string()), nullable())
+                safeMigrationTag: schema(string(), nullable())
+            ])
+            description: structure([
+                acceptedPattern: schema(string(), nullable())
+            ])
+        ])
+	])
+
+rules:
+    - NijiDigital\PhpStanRules\Rules\NoRelativeDatetime
+
+services:
+    -
+        class: NijiDigital\PhpStanRules\Rules\DoctrineMigrationsSafeMigration
+        arguments:
+            blacklistedQueries: %niji.doctrineMigrations.safeMigration.blacklistedQueries%
+            safeMigrationTag: %niji.doctrineMigrations.safeMigration.safeMigrationTag%
+        tags:
+            - phpstan.rules.rule
+    -
+        class: NijiDigital\PhpStanRules\Rules\DoctrineMigrationsDescription
+        arguments:
+            acceptedPattern: %niji.doctrineMigrations.description.acceptedPattern%
+        tags:
+            - phpstan.rules.rule
+
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,43 +1,11 @@
+includes:
+  - extension.neon
+  - vendor/phpstan/phpstan-deprecation-rules/rules.neon
+
 parameters:
-    niji:
-        doctrineMigrations:
-            safeMigration:
-                blacklistedQueries: null
-                safeMigrationTag: null
-            description:
-                acceptedPattern: null
+    level: max
+    paths:
+        - src
+        - tests
     excludePaths:
         - tests/*/data/*
-
-parametersSchema:
-	niji: structure([
-        doctrineMigrations: structure([
-            safeMigration: structure([
-                blacklistedQueries: schema(arrayOf(string()), nullable())
-                safeMigrationTag: schema(string(), nullable())
-            ])
-            description: structure([
-                acceptedPattern: schema(string(), nullable())
-            ])
-        ])
-	])
-
-rules:
-    - NijiDigital\PhpStanRules\Rules\NoRelativeDatetime
-
-services:
-    -
-        class: NijiDigital\PhpStanRules\Rules\DoctrineMigrationsSafeMigration
-        arguments:
-            blacklistedQueries: %niji.doctrineMigrations.safeMigration.blacklistedQueries%
-            safeMigrationTag: %niji.doctrineMigrations.safeMigration.safeMigrationTag%
-        tags:
-            - phpstan.rules.rule
-    -
-        class: NijiDigital\PhpStanRules\Rules\DoctrineMigrationsDescription
-        arguments:
-            acceptedPattern: %niji.doctrineMigrations.description.acceptedPattern%
-        tags:
-            - phpstan.rules.rule
-
-

--- a/src/Rules/DoctrineMigrationsSafeMigration.php
+++ b/src/Rules/DoctrineMigrationsSafeMigration.php
@@ -17,7 +17,6 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
-use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\Type;
 
@@ -112,17 +111,19 @@ class DoctrineMigrationsSafeMigration implements Rule
         // Check if the called method comes from the AbstractMigration class
         if (AbstractMigration::class === $methodDeclaringClass->getName()) {
             $parameters = $node->args;
-            if (
-                \count($parameters) >= 1 &&
-                ($parameters[0] instanceof Arg) &&
-                ($parameterType = $scope->getType($parameters[0]->value)) instanceof ConstantStringType &&
-                ($blacklistedQueryMessage = $this->getBlacklistedQueryMessage($node, $parameterType->getValue()))) {
-                return [
-                    RuleErrorBuilder::message($blacklistedQueryMessage)
-                        ->identifier(self::ERROR_IDENTIFIER)
-                        ->tip(sprintf(self::TIP, $this->safeMigrationTag))
-                        ->build(),
-                ];
+            if (\count($parameters) >= 1 && ($parameters[0] instanceof Arg)) {
+                $constantStrings = $scope->getType($parameters[0]->value)->getConstantStrings();
+                foreach ($constantStrings as $constantString) {
+                    $blacklistedQueryMessage = $this->getBlacklistedQueryMessage($node, $constantString->getValue());
+                    if ($blacklistedQueryMessage !== null) {
+                        return [
+                            RuleErrorBuilder::message($blacklistedQueryMessage)
+                                ->identifier(self::ERROR_IDENTIFIER)
+                                ->tip(sprintf(self::TIP, $this->safeMigrationTag))
+                                ->build(),
+                        ];
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Fix the following deprecation detected when attempting to merge on v2.x:

```
 ------ ---------------------------------------------------------------------------------------------------------------------------------- 
  Line   src/Rules/DoctrineMigrationsSafeMigration.php                                                                                     
 ------ ---------------------------------------------------------------------------------------------------------------------------------- 
  118    Doing instanceof PHPStan\Type\Constant\ConstantStringType is error-prone and deprecated. Use Type::getConstantStrings() instead.  
         💡 Learn more: https://phpstan.org/blog/why-is-instanceof-type-wrong-and-getting-deprecated                                       
 ------ ----------------------------------------------------------------------------------------------------------------------------------
```

I also added `phpstan/phpstan-deprecation-rules` so we can detect that kind of things earlier.

This required moving the current content of `phpstan.neon` to `extension.neon` (which will be included in end-users projects) and creating a new `phpstan.neon` file (which will be used to validate the code of this project).