### PR TITLE
DoctrineMigrationsSafeMigration: use standard phpstan-ignore comment instead of a custom PHPDoc tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ function doSomethingWithTime(ClockInterface $clock) {
 
 ### `DoctrineMigrationsSafeMigration`
 
-Detects potentially unsafe database migration operations that could break backward compatibility in Doctrine migrations. Operations can be marked as safe using the `@safe-migration` annotation.
+Detects potentially unsafe database migration operations that could break backward compatibility in Doctrine migrations. Operations can be marked as safe using PHPStan's standard `@phpstan-ignore` comment.
 
 #### Examples
 
@@ -86,16 +86,16 @@ class SafeMigration extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
-        // Safe operations (no annotation needed)
+        // Safe operations (no ignore comment needed)
         $this->addSql('ALTER TABLE user ADD COLUMN email VARCHAR(255)');
         $this->addSql('CREATE INDEX idx_user_email ON user (email)');
         $this->addSql('INSERT INTO user (name) VALUES (\'John\')');
 
         // Unsafe operations marked as intentionally safe
-        /** @safe-migration */
+        /* @phpstan-ignore doctrineMigrations.unsafeMigration */
         $this->addSql('DROP TABLE legacy_user');
 
-        /** @safe-migration */
+        /* @phpstan-ignore doctrineMigrations.unsafeMigration */
         $this->addSql('ALTER TABLE user CHANGE name full_name VARCHAR(255)');
     }
 }
@@ -114,14 +114,10 @@ parameters:
                 blacklistedQueries:
                     '/DROP\s+TABLE\s+/im': 'Dropping tables is not allowed'
                     '/ALTER\s+TABLE\s+.+\s+DROP\s+COLUMN/im': 'Dropping columns breaks backward compatibility'
-                # Custom annotation tag to mark operations as safe
-                # Make sure to escape @ characters
-                safeMigrationTag: '@@my-safe-migration'
 ```
 
 **Available options:**
 - `blacklistedQueries`: Array of regex patterns (as keys) with their corresponding error messages (as values). If not specified, uses default patterns for common unsafe operations.
-- `safeMigrationTag`: The annotation tag used to mark operations as intentionally safe. Defaults to `@safe-migration`.
 
 ### `DoctrineMigrationsDescription`
 

--- a/extension.neon
+++ b/extension.neon
@@ -3,7 +3,6 @@ parameters:
         doctrineMigrations:
             safeMigration:
                 blacklistedQueries: null
-                safeMigrationTag: null
             description:
                 acceptedPattern: null
 
@@ -12,7 +11,6 @@ parametersSchema:
         doctrineMigrations: structure([
             safeMigration: structure([
                 blacklistedQueries: schema(arrayOf(string()), nullable())
-                safeMigrationTag: schema(string(), nullable())
             ])
             description: structure([
                 acceptedPattern: schema(string(), nullable())
@@ -28,7 +26,6 @@ services:
         class: NijiDigital\PhpStanRules\Rules\DoctrineMigrationsSafeMigration
         arguments:
             blacklistedQueries: %niji.doctrineMigrations.safeMigration.blacklistedQueries%
-            safeMigrationTag: %niji.doctrineMigrations.safeMigration.safeMigrationTag%
         tags:
             - phpstan.rules.rule
     -

--- a/src/Rules/DoctrineMigrationsSafeMigration.php
+++ b/src/Rules/DoctrineMigrationsSafeMigration.php
@@ -10,9 +10,6 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
 use PHPStan\Analyser\Scope;
-use PHPStan\PhpDocParser\Lexer\Lexer;
-use PHPStan\PhpDocParser\Parser\PhpDocParser;
-use PHPStan\PhpDocParser\Parser\TokenIterator;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -27,9 +24,7 @@ class DoctrineMigrationsSafeMigration implements Rule
 {
     public const ERROR_IDENTIFIER = 'doctrineMigrations.unsafeMigration';
 
-    public const TIP = 'Avoid operations that are not backward compatibles or mark them as being safe using /** %s */';
-
-    public const DEFAULT_SAFE_MIGRATION_TAG = '@safe-migration';
+    public const TIP = 'Avoid operations that are not backward compatibles or mark them as being safe using /* @phpstan-ignore ' . self::ERROR_IDENTIFIER . ' */';
 
     public const DEFAULT_BLACKLISTED_QUERIES = [
         '/ALTER\s+TABLE\s+.+\s+CHANGE\s+/im' => 'An ALTER TABLE CHANGE operation (such as changing the type of a column) may not be backward compatible.',
@@ -39,23 +34,17 @@ class DoctrineMigrationsSafeMigration implements Rule
         '/TRUNCATE\s+/im' => 'A TRUNCATE operation may not be backward compatible.',
     ];
 
-    /** @var string[] */
+    /** @var array<string,string> */
     private readonly array $blacklistedQueries;
-
-    private readonly string $safeMigrationTag;
 
     /**
      * @param string[]|null $blacklistedQueries
      */
     public function __construct(
         private readonly RuleLevelHelper $ruleLevelHelper,
-        private readonly Lexer $phpDocLexer,
-        private readonly PhpDocParser $phpDocParser,
         ?array $blacklistedQueries = self::DEFAULT_BLACKLISTED_QUERIES,
-        ?string $safeMigrationTag = self::DEFAULT_SAFE_MIGRATION_TAG
     ) {
         $this->blacklistedQueries = $blacklistedQueries ?? self::DEFAULT_BLACKLISTED_QUERIES;
-        $this->safeMigrationTag = $safeMigrationTag ?? self::DEFAULT_SAFE_MIGRATION_TAG;
     }
 
     #[\Override]
@@ -114,12 +103,12 @@ class DoctrineMigrationsSafeMigration implements Rule
             if (\count($parameters) >= 1 && ($parameters[0] instanceof Arg)) {
                 $constantStrings = $scope->getType($parameters[0]->value)->getConstantStrings();
                 foreach ($constantStrings as $constantString) {
-                    $blacklistedQueryMessage = $this->getBlacklistedQueryMessage($node, $constantString->getValue());
+                    $blacklistedQueryMessage = $this->getBlacklistedQueryMessage($constantString->getValue());
                     if ($blacklistedQueryMessage !== null) {
                         return [
                             RuleErrorBuilder::message($blacklistedQueryMessage)
                                 ->identifier(self::ERROR_IDENTIFIER)
-                                ->tip(sprintf(self::TIP, $this->safeMigrationTag))
+                                ->tip(self::TIP)
                                 ->build(),
                         ];
                     }
@@ -130,12 +119,8 @@ class DoctrineMigrationsSafeMigration implements Rule
         return [];
     }
 
-    private function getBlacklistedQueryMessage(Node $node, string $sqlQuery): ?string
+    private function getBlacklistedQueryMessage(string $sqlQuery): ?string
     {
-        if ($this->isTaggedAsSafeMigration($node)) {
-            return null;
-        }
-
         foreach ($this->blacklistedQueries as $blacklistedQuery => $message) {
             if (preg_match($blacklistedQuery, $sqlQuery)) {
                 return $message;
@@ -143,25 +128,5 @@ class DoctrineMigrationsSafeMigration implements Rule
         }
 
         return null;
-    }
-
-    private function isTaggedAsSafeMigration(Node $node): bool
-    {
-        $docComment = $node->getDocComment();
-        if (null === $docComment) {
-            return false;
-        }
-
-        $phpDocString = $docComment->getText();
-        $phpDocTokens = new TokenIterator($this->phpDocLexer->tokenize($phpDocString));
-        $phpDocNode = $this->phpDocParser->parse($phpDocTokens);
-
-        foreach ($phpDocNode->getTags() as $phpDocTagNode) {
-            if ($this->safeMigrationTag === $phpDocTagNode->name) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/tests/Rules/DoctrineMigrationsSafeMigrationTest.php
+++ b/tests/Rules/DoctrineMigrationsSafeMigrationTest.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace NijiDigital\PhpStanRules\Tests\Rules;
 
 use NijiDigital\PhpStanRules\Rules\DoctrineMigrationsSafeMigration;
-use PHPStan\PhpDocParser\Lexer\Lexer;
-use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
@@ -18,7 +16,7 @@ class DoctrineMigrationsSafeMigrationTest extends RuleTestCase
 {
     public function testRule(): void
     {
-        $tip = sprintf('Avoid operations that are not backward compatibles or mark them as being safe using /** %s */', DoctrineMigrationsSafeMigration::DEFAULT_SAFE_MIGRATION_TAG);
+        $tip = DoctrineMigrationsSafeMigration::TIP;
 
         $this->analyse([__DIR__ . '/data/DoctrineMigrationsSafeMigration/UnsafeMigration.php'], [
             [
@@ -77,8 +75,6 @@ class DoctrineMigrationsSafeMigrationTest extends RuleTestCase
     {
         return new DoctrineMigrationsSafeMigration(
             $this->getContainer()->getByType(RuleLevelHelper::class),
-            $this->getContainer()->getByType(Lexer::class),
-            $this->getContainer()->getByType(PhpDocParser::class)
         );
     }
 }

--- a/tests/Rules/data/DoctrineMigrationsSafeMigration/UnsafeMigration.php
+++ b/tests/Rules/data/DoctrineMigrationsSafeMigration/UnsafeMigration.php
@@ -11,26 +11,26 @@ class UnsafeMigration extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
-        // Unsafe operations, not tagged as safe
+        // Unsafe operations, not ignored
         $this->addSql('DROP TABLE user');
         $this->addSql('ALTER TABLE user CHANGE name email VARCHAR(255) NOT NULL');
         $this->addSql('ALTER TABLE user DROP COLUMN name');
         $this->addSql('DROP DATABASE test');
         $this->addSql('TRUNCATE TABLE user');
 
-        // Unsafe operations, tagged as safe
-        /** @safe-migration */
+        // Unsafe operations, ignored
+        /* @phpstan-ignore doctrineMigrations.unsafeMigration */
         $this->addSql('DROP TABLE user');
-        /** @safe-migration */
+        /* @phpstan-ignore doctrineMigrations.unsafeMigration */
         $this->addSql('ALTER TABLE user CHANGE name email VARCHAR(255) NOT NULL');
-        /** @safe-migration */
+        /* @phpstan-ignore doctrineMigrations.unsafeMigration */
         $this->addSql('ALTER TABLE user DROP COLUMN name');
 
-        // Some unsafe operations again to make sure that the tag does not apply to them
+        // Some unsafe operations again to make sure that the ignore tags do not apply to them
         $this->addSql('DROP TABLE user');
         $this->addSql('TRUNCATE TABLE user');
 
-        // Safe operations (do not impact backward compatibility and do not need to be tagged as safe)
+        // Safe operations (do not impact backward compatibility and do not need to be ignored)
         $this->addSql('ALTER TABLE user ADD COLUMN name VARCHAR(255) NOT NULL');
         $this->addSql('SELECT * FROM user');
         $this->addSql("INSERT INTO user (name) VALUES ('John')");


### PR DESCRIPTION
It seems that the PHPDoc tag detection for the "safe-migration" feature does not work in v2.x.
Instead of trying to fix it we could simply recommend using native `@phpstan-ignore` comments.